### PR TITLE
Convert weapons.lua requirement to ox

### DIFF
--- a/client/evidence.lua
+++ b/client/evidence.lua
@@ -1,4 +1,3 @@
-local config = require 'config.client'
 local currentStatusList = {}
 local casings = {}
 local currentCasing = nil
@@ -7,6 +6,8 @@ local currentBloodDrop = nil
 local fingerprints = {}
 local currentFingerprint = 0
 local shotAmount = 0
+
+local qbShared = require '@qbx_core.shared.main'
 
 local statusList = {
     fight = Lang:t('evidence.red_hands'),
@@ -255,7 +256,7 @@ CreateThread(function()
                 metadata = {
                     type = Lang:t('info.casing'),
                     street = getStreetLabel(casings[currentCasing].coords),
-                    ammolabel = config.ammoLabels[exports.qbx_core:GetWeapons()[casings[currentCasing].type].ammotype],
+                    ammolabel = qbShared.AmmoTypes[qbShared.WeaponHashes[casings[currentCasing].type].ammoname].label,
                     ammotype = casings[currentCasing].type,
                     serie = casings[currentCasing].serie
                 },

--- a/config/client.lua
+++ b/config/client.lua
@@ -115,15 +115,6 @@ return {
 
     whitelistedVehicles = {},
 
-    ammoLabels = {
-        AMMO_PISTOL = '9x19mm parabellum bullet',
-        AMMO_SMG = '9x19mm parabellum bullet',
-        AMMO_RIFLE = '7.62x39mm bullet',
-        AMMO_MG = '7.92x57mm mauser bullet',
-        AMMO_SHOTGUN = '12-gauge bullet',
-        AMMO_SNIPER = 'Large caliber bullet',
-    },
-
     radars = {
         -- Radars will fine the driver if the vehicle is over the defined speed limit
         -- Regardless of the speed, If the vehicle is flagged it sends a notification to the police


### PR DESCRIPTION
## Description

Makes it use ox_inventory instead of the weapons.lua from qbcore.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
