### PR TITLE
fix(impound): set vehicle props reliably

### DIFF
--- a/client/job.lua
+++ b/client/job.lua
@@ -82,9 +82,7 @@ local function takeOutImpound(vehicle)
     if not inImpound then return end
     local coords = sharedConfig.locations.impound[currentGarage]
     if not coords then return end
-
-    local properties = lib.callback.await('qb-garage:server:GetVehicleProperties', false, vehicle.plate)
-    local netId = lib.callback.await('qbx_policejob:server:spawnVehicle', false, vehicle.vehicle, coords, vehicle.plate, vehicle.id, properties)
+    local netId = lib.callback.await('qbx_policejob:server:spawnVehicle', false, vehicle.vehicle, coords, vehicle.plate, true, vehicle.id)
 
     local veh = lib.waitFor(function()
         if NetworkDoesEntityExistWithNetworkId(netId) then

--- a/client/job.lua
+++ b/client/job.lua
@@ -83,7 +83,8 @@ local function takeOutImpound(vehicle)
     local coords = sharedConfig.locations.impound[currentGarage]
     if not coords then return end
 
-    local netId = lib.callback.await('qbx_policejob:server:spawnVehicle', false, vehicle.vehicle, coords, vehicle.plate, vehicle.id)
+    local properties = lib.callback.await('qb-garage:server:GetVehicleProperties', false, vehicle.plate)
+    local netId = lib.callback.await('qbx_policejob:server:spawnVehicle', false, vehicle.vehicle, coords, vehicle.plate, vehicle.id, properties)
 
     local veh = lib.waitFor(function()
         if NetworkDoesEntityExistWithNetworkId(netId) then
@@ -91,8 +92,6 @@ local function takeOutImpound(vehicle)
         end
     end)
 
-    local properties = lib.callback.await('qb-garage:server:GetVehicleProperties', false, vehicle.plate)
-    lib.setVehicleProperties(veh, properties)
     SetVehicleFuelLevel(veh, vehicle.fuel)
     doCarDamage(veh, vehicle)
     TriggerServerEvent('police:server:TakeOutImpound', vehicle.plate, currentGarage)

--- a/server/main.lua
+++ b/server/main.lua
@@ -102,11 +102,12 @@ lib.callback.register('police:GetImpoundedVehicles', function()
     return FetchImpoundedVehicles()
 end)
 
-lib.callback.register('qbx_policejob:server:spawnVehicle', function(source, model, coords, plate, giveKeys, vehId)
+lib.callback.register('qbx_policejob:server:spawnVehicle', function(source, model, coords, plate, giveKeys, vehId, vehProps)
     local netId, veh = qbx.spawnVehicle({
         model = model,
         spawnSource = coords,
-        warp = GetPlayerPed(source)
+        warp = GetPlayerPed(source),
+        props = vehProps
     })
 
     if not netId or netId == 0 or not veh or veh == 0 then return end

--- a/server/main.lua
+++ b/server/main.lua
@@ -102,8 +102,16 @@ lib.callback.register('police:GetImpoundedVehicles', function()
     return FetchImpoundedVehicles()
 end)
 
+lib.callback.register('qbx_policejob:server:spawnVehicle', function(source, model, coords, plate, giveKeys, vehId)
     local player = exports.qbx_core:GetPlayer(source)
     if player.PlayerData.job.type ~= 'leo' then return end
+
+    local vehProps = {}
+    if exports.qbx_vehicles:DoesEntityPlateExist(plate) then
+        local vehicle = exports.qbx_vehicles:FetchEntitiesByPlate(plate)
+        vehProps = vehicle.mods
+    end
+
     local netId, veh = qbx.spawnVehicle({
         model = model,
         spawnSource = coords,

--- a/server/main.lua
+++ b/server/main.lua
@@ -102,7 +102,8 @@ lib.callback.register('police:GetImpoundedVehicles', function()
     return FetchImpoundedVehicles()
 end)
 
-lib.callback.register('qbx_policejob:server:spawnVehicle', function(source, model, coords, plate, giveKeys, vehId, vehProps)
+    local player = exports.qbx_core:GetPlayer(source)
+    if player.PlayerData.job.type ~= 'leo' then return end
     local netId, veh = qbx.spawnVehicle({
         model = model,
         spawnSource = coords,


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->
qbx.spawnVehicle supports props so we need to send these to the server to set on the vehicle via statebag. Additionally the arguments for the spawn are out of order for impound cars resulting in keys not being given when pulling from impound.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
