### PR TITLE
fix(vehicles): use zones instead of targets

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -178,39 +178,33 @@ local function createGarage(job, garages)
 
     for i = 1, #garages do
         local garage = garages[i]
+        local hasGroup = exports.qbx_core:HasGroup(garage.groups)
 
-        exports.ox_target:addSphereZone({
+        lib.zones.sphere({
             coords = garage.coords,
             radius = garage.radius,
             debug = config.debugPoly,
-            options = {
-                {
-                    name = ('%s-Garage'):format(job),
-                    icon = 'fa-solid fa-warehouse',
-                    label = locale('targets.garage'),
-                    canInteract = function()
-                        return not cache.vehicle and QBX.PlayerData.job.onduty
-                    end,
-                    onSelect = function()
-                        vehicles.openGarage(garage)
-                    end,
-                    groups = garage.groups,
-                    distance = 1.5,
-                },
-                {
-                    name = ('%s-GarageStore'):format(job),
-                    icon = 'fa-solid fa-square-parking',
-                    label = locale('targets.store_vehicle'),
-                    canInteract = function()
-                        return cache.vehicle and QBX.PlayerData.job.onduty
-                    end,
-                    onSelect = function()
+            onEnter = function()
+                if not hasGroup or not QBX.PlayerData.job.onduty then return end
+
+                lib.showTextUI(cache.vehicle and locale('vehicles.store_vehicle') or locale('vehicles.open_garage'))
+            end,
+            inside = function()
+                if not hasGroup or not QBX.PlayerData.job.onduty then return end
+
+                if IsControlJustReleased(0, 38) then
+                    if cache.vehicle then
                         vehicles.store(cache.vehicle)
-                    end,
-                    groups = garage.groups,
-                    distance = 1.5,
-                },
-            }
+                    else
+                        vehicles.openHelipad(garage)
+                    end
+
+                    lib.hideTextUI()
+                end
+            end,
+            onExit = function()
+                lib.hideTextUI()
+            end,
         })
     end
 end
@@ -222,39 +216,33 @@ local function createHelipad(job, helipads)
 
     for i = 1, #helipads do
         local helipad = helipads[i]
+        local hasGroup = exports.qbx_core:HasGroup(helipad.groups)
 
-        exports.ox_target:addSphereZone({
+        lib.zones.sphere({
             coords = helipad.coords,
             radius = helipad.radius,
             debug = config.debugPoly,
-            options = {
-                {
-                    name = ('%s-Helipad'):format(job),
-                    icon = 'fa-solid fa-helicopter-symbol',
-                    label = locale('targets.helipad'),
-                    canInteract = function()
-                        return not cache.vehicle and QBX.PlayerData.job.onduty
-                    end,
-                    onSelect = function()
-                        vehicles.openHelipad(helipad)
-                    end,
-                    groups = helipad.groups,
-                    distance = 1.5,
-                },
-                {
-                    name = ('%s-HelipadStore'):format(job),
-                    icon = 'fa-solid fa-square-parking',
-                    label = locale('targets.store_helicopter'),
-                    canInteract = function()
-                        return cache.vehicle and QBX.PlayerData.job.onduty
-                    end,
-                    onSelect = function()
+            onEnter = function()
+                if not hasGroup or not QBX.PlayerData.job.onduty then return end
+
+                lib.showTextUI(cache.vehicle and locale('vehicles.store_helicopter') or locale('vehicles.open_helipad'))
+            end,
+            inside = function()
+                if not hasGroup or not QBX.PlayerData.job.onduty then return end
+
+                if IsControlJustReleased(0, 38) then
+                    if cache.vehicle then
                         vehicles.store(cache.vehicle)
-                    end,
-                    groups = helipad.groups,
-                    distance = 1.5,
-                },
-            }
+                    else
+                        vehicles.openHelipad(helipad)
+                    end
+
+                    lib.hideTextUI()
+                end
+            end,
+            onExit = function()
+                lib.hideTextUI()
+            end,
         })
     end
 end
@@ -360,6 +348,7 @@ RegisterNetEvent('QBCore:Client:OnJobUpdate', function()
     })
 end)
 
+---@diagnostic disable-next-line: param-type-mismatch
 AddStateBagChangeHandler('DEATH_STATE_STATE_BAG', nil, function(bagName, _, dead)
     local player = GetPlayerFromStateBagName(bagName)
 

--- a/client/main.lua
+++ b/client/main.lua
@@ -178,18 +178,21 @@ local function createGarage(job, garages)
 
     for i = 1, #garages do
         local garage = garages[i]
-        local hasGroup = exports.qbx_core:HasGroup(garage.groups)
 
         lib.zones.sphere({
             coords = garage.coords,
             radius = garage.radius,
             debug = config.debugPoly,
             onEnter = function()
+                local hasGroup = exports.qbx_core:HasGroup(garage.groups)
+
                 if not hasGroup or not QBX.PlayerData.job.onduty then return end
 
                 lib.showTextUI(cache.vehicle and locale('vehicles.store_vehicle') or locale('vehicles.open_garage'))
             end,
             inside = function()
+                local hasGroup = exports.qbx_core:HasGroup(garage.groups)
+
                 if not hasGroup or not QBX.PlayerData.job.onduty then return end
 
                 if IsControlJustReleased(0, 38) then
@@ -216,18 +219,21 @@ local function createHelipad(job, helipads)
 
     for i = 1, #helipads do
         local helipad = helipads[i]
-        local hasGroup = exports.qbx_core:HasGroup(helipad.groups)
 
         lib.zones.sphere({
             coords = helipad.coords,
             radius = helipad.radius,
             debug = config.debugPoly,
             onEnter = function()
+                local hasGroup = exports.qbx_core:HasGroup(helipad.groups)
+
                 if not hasGroup or not QBX.PlayerData.job.onduty then return end
 
                 lib.showTextUI(cache.vehicle and locale('vehicles.store_helicopter') or locale('vehicles.open_helipad'))
             end,
             inside = function()
+                local hasGroup = exports.qbx_core:HasGroup(helipad.groups)
+
                 if not hasGroup or not QBX.PlayerData.job.onduty then return end
 
                 if IsControlJustReleased(0, 38) then

--- a/client/vehicles.lua
+++ b/client/vehicles.lua
@@ -5,7 +5,7 @@ local function store(vehicle)
     DeleteVehicle(vehicle)
 end
 
----@param vehicle string
+---@param vehicle CatalogueItem
 ---@param spawn vector4
 local function takeOut(vehicle, spawn)
     if cache.vehicle then
@@ -13,12 +13,10 @@ local function takeOut(vehicle, spawn)
         return
     end
 
-    local netId = lib.callback.await('s_police:server:spawnVehicle', false, vehicle, spawn)
+    local netId = lib.callback.await('qbx_police:server:spawnVehicle', false, vehicle, spawn)
 
     lib.waitFor(function()
-        if NetworkDoesEntityExistWithNetworkId(netId) then
-            return NetToVeh(netId)
-        end
+        return NetworkDoesEntityExistWithNetworkId(netId)
     end, locale('vehicles.something_wrong'))
 end
 
@@ -26,7 +24,9 @@ end
 local function openGarage(garage)
     local options = {}
 
-    for _, vehicle in pairs(garage.catalogue) do
+    for i = 1, #garage.catalogue do
+        local vehicle = garage.catalogue[i]
+
         if vehicle.grade <= QBX.PlayerData.job.grade.level then
             local title = ('%s %s'):format(VEHICLES[vehicle.name].brand, VEHICLES[vehicle.name].name)
 
@@ -34,7 +34,7 @@ local function openGarage(garage)
                 title = title,
                 arrow = true,
                 onSelect = function()
-                    takeOut(vehicle.name, garage.spawn)
+                    takeOut(vehicle, garage.spawn)
                 end,
             }
         end
@@ -53,15 +53,17 @@ end
 local function openHelipad(helipad)
     local options = {}
 
-    for _, heli in pairs(helipad.catalogue) do
-        if heli.grade <= QBX.PlayerData.job.grade.level then
-            local title = ('%s %s'):format(VEHICLES[heli.name].brand, VEHICLES[heli.name].name)
+    for i = 1, #helipad.catalogue do
+        local helicopter = helipad.catalogue[i]
+
+        if helicopter.grade <= QBX.PlayerData.job.grade.level then
+            local title = ('%s %s'):format(VEHICLES[helicopter.name].brand, VEHICLES[helicopter.name].name)
 
             options[#options + 1] = {
                 title = title,
                 arrow = true,
                 onSelect = function()
-                    takeOut(heli.name, helipad.spawn)
+                    takeOut(helicopter, helipad.spawn)
                 end,
             }
         end
@@ -74,7 +76,7 @@ local function openHelipad(helipad)
 
     lib.registerContext({
         id = 'helipadMenu',
-        title = locale('vehicles.heipad_title'),
+        title = locale('vehicles.helipad_title'),
         options = options
     })
 

--- a/config/server.lua
+++ b/config/server.lua
@@ -1,1 +1,5 @@
-return {}
+return {
+    giveVehicleKeys = function(src, plate)
+        return exports.qbx_vehiclekeys:GiveKeys(src, plate)
+    end,
+}

--- a/config/shared.lua
+++ b/config/shared.lua
@@ -75,8 +75,8 @@ return {
             },
             garage = {
                 {
-                    coords = vec3(-586.17, -427.92, 31.16),
-                    spawn = vec4(-588.28, -419.13, 30.59, 270.21),
+                    coords = vec3(452.26, -997.18, 25.76),
+                    spawn = vec4(452.26, -997.18, 25.76, 180.0),
                     radius = 2.5,
                     catalogue = {
                         { name = 'police', grade = 0 },
@@ -90,8 +90,8 @@ return {
             },
             helipad = {
                 {
-                    coords = vec3(-595.85, -431.48, 51.38),
-                    spawn = vec4(-595.85, -431.48, 51.38, 2.56),
+                    coords = vec3(449.23, -981.28, 43.69),
+                    spawn = vec4(449.23, -981.28, 43.69, 0.0),
                     radius = 2.5,
                     catalogue = {
                         { name = 'polmav', grade = 0 },

--- a/locales/en.json
+++ b/locales/en.json
@@ -5,11 +5,7 @@
         "boss_menu": "Open Job Management",
         "armory": "Open Armory",
         "personal_stash": "Open Personal Stash",
-        "evidence_drawers": "Open Evidence Drawers",
-        "garage": "Open Garage",
-        "store_vehicle": "Store Vehicle",
-        "helipad": "Open Helipad",
-        "store_helicopter": "Store Helicopter"
+        "evidence_drawers": "Open Evidence Drawers"
     },
     "radial": {
         "label": "Police",
@@ -26,6 +22,10 @@
         "not_around": "It looks like that person is not around right now..."
     },
     "vehicles": {
+        "open_helipad": "E - Open Helipad",
+        "store_helicopter": "E - Store Helicopter",
+        "open_garage": "E - Open Garage",
+        "store_vehicle": "E - Store Vehicle",
         "garage_title": "PD Garage",
         "helipad_title": "PD Helipad",
         "not_helipad_grade": "You're not the appropriate grade to pilot a helicopter yet...",

--- a/server/main.lua
+++ b/server/main.lua
@@ -1,3 +1,4 @@
+local config = require 'config.server'
 local sharedConfig = require 'config.shared'
 
 ---@param job? string
@@ -25,21 +26,22 @@ local function registerArmory(department)
 end
 
 ---@param source number
----@param model string
+---@param vehicle table
 ---@param spawn vector4
-lib.callback.register('qbx_police:server:spawnVehicle', function(source, model, spawn)
+lib.callback.register('qbx_police:server:spawnVehicle', function(source, vehicle, spawn)
     local ped = GetPlayerPed(source)
     local plate = ('LSPD%s'):format(math.random(1000, 9999))
     local netId, _ = qbx.spawnVehicle({
         spawnSource = spawn,
-        model = model,
+        model = vehicle.name,
         warp = ped,
         props = {
-            plate = plate
+            plate = plate,
+            modLivery = vehicle.livery or 0
         }
     })
 
-    exports.qbx_vehiclekeys:GiveKeys(source, plate)
+    config.giveVehicleKeys(source, plate)
 
     return netId
 end)

--- a/types.lua
+++ b/types.lua
@@ -47,6 +47,7 @@
 ---@class CatalogueItem
 ---@field name string
 ---@field grade number
+---@field livery? number default is 0
 
 ---@class VehicleData
 ---@field coords vector3


### PR DESCRIPTION
## Description

- Switches to the use of zones for vehicle spawning as it makes more sense and works better
- Use numeric for loops as we are iterating over arrays
- Send vehicle table instead of just the model so we can add the ability for vehicle customization by config

Once this PR is finalized, I'll make the same adjustments to the qbx_ambulancejob rewrite

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
