### PR TITLE
fix(server): use new GiveKeys export properly

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -112,7 +112,7 @@ lib.callback.register('qbx_policejob:server:spawnVehicle', function(source, mode
     if not netId or netId == 0 or not veh or veh == 0 then return end
 
     SetVehicleNumberPlateText(veh, plate)
-    if giveKeys == true then exports.qbx_vehiclekeys:GiveKeys(source, plate) end
+    if giveKeys == true then exports.qbx_vehiclekeys:GiveKeys(source, veh) end
 
     if vehId then Entity(veh).state.vehicleid = vehId end
     return netId


### PR DESCRIPTION
## Description

Use vehicle instead of plate after this commit: https://github.com/Qbox-project/qbx_vehiclekeys/commit/146c7df4b42655ad1182536b8b95a9e133bba96b

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
