### PR TITLE
fix(server/commands): use new core exports

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -258,18 +258,6 @@ local function registerAliveRadial()
         id = 'policeMenu',
         items = {
             {
-                icon = 'lock',
-                label = locale('radial.cuff'),
-                onSelect = function()
-                end,
-            },
-            {
-                icon = 'lock-open',
-                label = locale('radial.uncuff'),
-                onSelect = function()
-                end,
-            },
-            {
                 icon = 'magnifying-glass',
                 label = locale('radial.search'),
                 onSelect = function()

--- a/server/commands.lua
+++ b/server/commands.lua
@@ -12,7 +12,7 @@ lib.addCommand('callsign', {
 
     if not player or player.PlayerData.job.type ~= 'leo' and player.PlayerData.job.type ~= 'ems' then return end
 
-    player.Functions.SetMetaData('callsign', args.callsign)
+    exports.qbx_core:SetMetadata(source, 'callsign', args.callsign)
 end)
 
 lib.addCommand('fine', {
@@ -41,8 +41,7 @@ lib.addCommand('fine', {
         return
     end
 
-    target.Functions.RemoveMoney('bank', args.amount, locale('commands.fine.issuer'))
-
+    exports.qbx_core:RemoveMoney(source, 'bank', args.amount, locale('commands.fine.issuer'))
     exports.qbx_core:Notify(source, locale('commands.fine.issued'), 'success')
     exports.qbx_core:Notify(target, locale('commands.fine.fined', args.amount), 'error')
 end)


### PR DESCRIPTION
## Description

- Replaced player function calls with their new core export counterparts
- Removed the planned cuff and uncuff radial menu options (for now)

## Checklist

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
