### PR TITLE
fix: /911p multiple parameters

### DIFF
--- a/server/commands.lua
+++ b/server/commands.lua
@@ -387,9 +387,9 @@ lib.addCommand('911p', {
         type = 'string',
         help = locale('commands.message_sent')
     }},
-}, function(source, args)
+}, function(source, args, raw)
     local message
-    if args.message then message = table.concat(args, ' ') else message = locale('commands.civilian_call') end
+    if args.message then message = raw:sub(6) else message = locale('commands.civilian_call') end
     local ped = GetPlayerPed(source)
     local coords = GetEntityCoords(ped)
     local players = exports.qbx_core:GetQBPlayers()

--- a/server/commands.lua
+++ b/server/commands.lua
@@ -388,7 +388,7 @@ lib.addCommand('911p', {
         help = locale('commands.message_sent')
     }},
 }, function(source, args)
-    local message = args.message and args.message or locale('commands.civilian_call')
+    local message = args.message or locale('commands.civilian_call')
     local ped = GetPlayerPed(source)
     local coords = GetEntityCoords(ped)
     local players = exports.qbx_core:GetQBPlayers()

--- a/server/commands.lua
+++ b/server/commands.lua
@@ -384,12 +384,11 @@ lib.addCommand('911p', {
     help = locale('commands.police_report'),
     params = {{
         name = 'message',
-        type = 'string',
+        type = 'longString',
         help = locale('commands.message_sent')
     }},
-}, function(source, args, raw)
-    local message
-    if args.message then message = raw:sub(6) else message = locale('commands.civilian_call') end
+}, function(source, args)
+    local message = args.message and args.message or locale('commands.civilian_call')
     local ped = GetPlayerPed(source)
     local coords = GetEntityCoords(ped)
     local players = exports.qbx_core:GetQBPlayers()


### PR DESCRIPTION
## Description

Fixes [an issue with sending a /911p call with multiple words/parameters](https://github.com/Qbox-project/qbx_police/issues/150).

## Checklist

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.