### PR TITLE
Prevent accessing inventory while cuffed

### DIFF
--- a/client/interactions.lua
+++ b/client/interactions.lua
@@ -327,6 +327,7 @@ RegisterNetEvent('police:client:GetCuffed', function(playerId, isSoftcuff)
     if not QBX.PlayerData.metadata.ishandcuffed then
         TriggerServerEvent('police:server:SetHandcuffStatus', true)
         ClearPedTasksImmediately(cache.ped)
+        LocalPlayer.state.invBusy = true
         if cache.weapon ~= `WEAPON_UNARMED` then
             SetCurrentPedWeapon(cache.ped, `WEAPON_UNARMED`, true)
         end
@@ -339,6 +340,7 @@ RegisterNetEvent('police:client:GetCuffed', function(playerId, isSoftcuff)
                 if isSuccess then
                     TriggerServerEvent('police:server:SetHandcuffStatus', false)
                     ClearPedTasksImmediately(cache.ped)
+                    LocalPlayer.state.invBusy = false
                     exports.qbx_core:Notify(locale('success.escapedcuff'), 'success')
                     return
                 end
@@ -349,6 +351,7 @@ RegisterNetEvent('police:client:GetCuffed', function(playerId, isSoftcuff)
         getCuffedAnimation(playerId)
     else
         IsEscorted = false
+        LocalPlayer.state.invBusy = false
         TriggerEvent('hospital:client:isEscorted', IsEscorted)
         DetachEntity(cache.ped, true, false)
         TriggerServerEvent('police:server:SetHandcuffStatus', false)


### PR DESCRIPTION
Stops players accessing their inventory while they're cuffed.

## Description

Stops players from accessing their inventory while cuffed.

## Checklist

- [X ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [X ] My pull request fits the contribution guidelines & code conventions.
