### PR TITLE
fix/feat(client): Use correct callback name / Disable inventory while cuffed

### DIFF
--- a/client/anpr.lua
+++ b/client/anpr.lua
@@ -22,7 +22,7 @@ local function handleSpeedCam(speedCam, radar)
     local speed = GetEntitySpeed(cache.vehicle) * (config.useMPH and 2.236936 or 3.6)
     local overLimit = speed - speedCam.speed
 
-    lib.callback('police:server:isPlateFlagged', false, function(result)
+    lib.callback('qbx_police:server:isPlateFlagged', false, function(result)
         if not result then return end
         local s1, s2 = GetStreetNameAtCoord(speedCam.coords.x, speedCam.coords.y, speedCam.coords.z)
         local street = GetStreetNameFromHashKey(s1)

--- a/client/anpr.lua
+++ b/client/anpr.lua
@@ -18,11 +18,11 @@ end
 
 local function handleSpeedCam(speedCam, radar)
     if not cache.vehicle or cache.seat ~= -1 or GetVehicleClass(cache.vehicle) == 18 then return end
-    local plate =  qbx.getVehiclePlate(cache.vehicle)
+    local plate = qbx.getVehiclePlate(cache.vehicle)
     local speed = GetEntitySpeed(cache.vehicle) * (config.useMPH and 2.236936 or 3.6)
     local overLimit = speed - speedCam.speed
 
-    lib.callback('qbx_police:server:isPlateFlagged', false, function(result)
+    lib.callback('police:server:isPlateFlagged', false, function(result)
         if not result then return end
         local s1, s2 = GetStreetNameAtCoord(speedCam.coords.x, speedCam.coords.y, speedCam.coords.z)
         local street = GetStreetNameFromHashKey(s1)

--- a/client/interactions.lua
+++ b/client/interactions.lua
@@ -326,6 +326,7 @@ end)
 RegisterNetEvent('police:client:GetCuffed', function(playerId, isSoftcuff)
     if not QBX.PlayerData.metadata.ishandcuffed then
         TriggerServerEvent('police:server:SetHandcuffStatus', true)
+        LocalPlayer.state.invBusy = true
         ClearPedTasksImmediately(cache.ped)
         if cache.weapon ~= `WEAPON_UNARMED` then
             SetCurrentPedWeapon(cache.ped, `WEAPON_UNARMED`, true)
@@ -338,6 +339,7 @@ RegisterNetEvent('police:client:GetCuffed', function(playerId, isSoftcuff)
                 local isSuccess = lib.skillCheck(config.breakCuffsDifficulty, config.breakCuffsKeys)
                 if isSuccess then
                     TriggerServerEvent('police:server:SetHandcuffStatus', false)
+                    LocalPlayer.state.invBusy = false
                     ClearPedTasksImmediately(cache.ped)
                     exports.qbx_core:Notify(locale('success.escapedcuff'), 'success')
                     return
@@ -352,6 +354,7 @@ RegisterNetEvent('police:client:GetCuffed', function(playerId, isSoftcuff)
         TriggerEvent('hospital:client:isEscorted', IsEscorted)
         DetachEntity(cache.ped, true, false)
         TriggerServerEvent('police:server:SetHandcuffStatus', false)
+        LocalPlayer.state.invBusy = false
         ClearPedTasksImmediately(cache.ped)
         TriggerServerEvent('InteractSound_SV:PlayOnSource', 'Uncuff', 0.2)
         exports.qbx_core:Notify(locale('success.uncuffed'), 'success')

--- a/client/interactions.lua
+++ b/client/interactions.lua
@@ -50,13 +50,13 @@ end
 local function handcuffActions()
     lib.disableControls()
     DisableControlAction(27, 75, true) -- Disable exit vehicle
-    EnableControlAction(0, 249, true) -- Added for talking while cuffed
-    EnableControlAction(0, 46, true)  -- Added for talking while cuffed
+    EnableControlAction(0, 249, true)  -- Added for talking while cuffed
+    EnableControlAction(0, 46, true)   -- Added for talking while cuffed
 end
 
 local function handcuffedEscorted()
     local sleep = 1000
-    local anim = {{dict = 'mp_arresting', anim = 'idle'}, {dict = 'mp_arrest_paired', anim = 'crook_p2_back_right'}}
+    local anim = { { dict = 'mp_arresting', anim = 'idle' }, { dict = 'mp_arrest_paired', anim = 'crook_p2_back_right' } }
 
     if not LocalPlayer.state.isLoggedIn then return sleep end
     if IsEscorted then
@@ -135,30 +135,30 @@ RegisterNetEvent('police:client:RobPlayer', function()
     local playerId = GetPlayerServerId(player)
 
     if not (IsEntityPlayingAnim(playerPed, 'missminuteman_1ig_2', 'handsup_base', 3)
-        or IsEntityPlayingAnim(playerPed, 'mp_arresting', 'idle', 3)
-        or isTargetDead(playerId))
+            or IsEntityPlayingAnim(playerPed, 'mp_arresting', 'idle', 3)
+            or isTargetDead(playerId))
     then
         return exports.qbx_core:Notify(locale('error.no_rob'), 'error')
     end
 
     if lib.progressCircle({
-        duration = math.random(5000, 7000),
-        position = 'bottom',
-        label = locale('progressbar.robbing'),
-        useWhileDead = false,
-        canCancel = true,
-        disable = {
-            move = true,
-            car = true,
-            combat = true,
-            mouse = false
-        },
-        anim = {
-            dict = 'random@shop_robbery',
-            clip = 'robbery_action_b',
-            flags = 16
-        }
-    })
+            duration = math.random(5000, 7000),
+            position = 'bottom',
+            label = locale('progressbar.robbing'),
+            useWhileDead = false,
+            canCancel = true,
+            disable = {
+                move = true,
+                car = true,
+                combat = true,
+                mouse = false
+            },
+            anim = {
+                dict = 'random@shop_robbery',
+                clip = 'robbery_action_b',
+                flags = 16
+            }
+        })
     then
         local playerCoords = GetEntityCoords(playerPed)
         local pos = GetEntityCoords(cache.ped)
@@ -180,7 +180,7 @@ RegisterNetEvent('police:client:JailPlayer', function()
     if not player then return end
     local playerId = GetPlayerServerId(player)
     local dialog = lib.inputDialog(locale('info.jail_time_input'), {
-        {type = 'number', label = locale('info.time_months'), min = 0}
+        { type = 'number', label = locale('info.time_months'), min = 0 }
     })
     if dialog and dialog[1] > 0 then
         TriggerServerEvent('police:server:JailPlayer', playerId, dialog[1])
@@ -194,7 +194,7 @@ RegisterNetEvent('police:client:BillPlayer', function()
     if not player then return end
     local playerId = GetPlayerServerId(player)
     local dialog = lib.inputDialog(locale('info.bill'), {
-        {type = 'number', label = locale('info.amount'), min = 0}
+        { type = 'number', label = locale('info.amount'), min = 0 }
     })
     if dialog and dialog[1] > 0 then
         TriggerServerEvent('police:server:BillPlayer', playerId, dialog[1])
@@ -267,17 +267,20 @@ RegisterNetEvent('police:client:CuffPlayer', function()
 end)
 
 RegisterNetEvent('police:client:GetEscorted', function(playerId)
-    if not(QBX.PlayerData.metadata.isdead
-        or QBX.PlayerData.metadata.ishandcuffed
-        or QBX.PlayerData.metadata.inlaststand)
-    then return end
+    if not (QBX.PlayerData.metadata.isdead
+            or QBX.PlayerData.metadata.ishandcuffed
+            or QBX.PlayerData.metadata.inlaststand)
+    then
+        return
+    end
 
     if not IsEscorted then
         IsEscorted = true
         local dragger = GetPlayerPed(GetPlayerFromServerId(playerId))
         local offset = GetOffsetFromEntityInWorldCoords(dragger, 0.0, 0.45, 0.0)
         SetEntityCoords(cache.ped, offset.x, offset.y, offset.z, true, false, false, false)
-        AttachEntityToEntity(cache.ped, dragger, 11816, 0.45, 0.45, 0.0, 0.0, 0.0, 0.0, false, false, false, false, 2, true)
+        AttachEntityToEntity(cache.ped, dragger, 11816, 0.45, 0.45, 0.0, 0.0, 0.0, 0.0, false, false, false, false, 2,
+            true)
     else
         IsEscorted = false
         DetachEntity(cache.ped, true, false)
@@ -292,7 +295,7 @@ RegisterNetEvent('police:client:DeEscort', function()
 end)
 
 RegisterNetEvent('police:client:GetKidnappedTarget', function(playerId)
-    if     QBX.PlayerData.metadata.isdead
+    if QBX.PlayerData.metadata.isdead
         or QBX.PlayerData.metadata.ishandcuffed
         or QBX.PlayerData.metadata.inlaststand
     then
@@ -300,7 +303,8 @@ RegisterNetEvent('police:client:GetKidnappedTarget', function(playerId)
             IsEscorted = true
             local dragger = GetPlayerPed(GetPlayerFromServerId(playerId))
             lib.playAnim(cache.ped, 'nm', 'firemans_carry', 8.0, -8.0, 100000, 33, 0, false, false, false)
-            AttachEntityToEntity(cache.ped, dragger, 0, 0.27, 0.15, 0.63, 0.5, 0.5, 0.0, false, false, false, false, 2, false)
+            AttachEntityToEntity(cache.ped, dragger, 0, 0.27, 0.15, 0.63, 0.5, 0.5, 0.0, false, false, false, false, 2,
+                false)
         else
             IsEscorted = false
             DetachEntity(cache.ped, true, false)
@@ -312,7 +316,8 @@ end)
 
 RegisterNetEvent('police:client:GetKidnappedDragger', function()
     if not isEscorting then
-        lib.playAnim(cache.ped, 'missfinale_c2mcs_1', 'fin_c2_mcs_1_camman', 8.0, -8.0, 100000, 49, 0, false, false, false)
+        lib.playAnim(cache.ped, 'missfinale_c2mcs_1', 'fin_c2_mcs_1_camman', 8.0, -8.0, 100000, 49, 0, false, false,
+            false)
         isEscorting = true
     else
         ClearPedSecondaryTask(cache.ped)
@@ -326,7 +331,6 @@ end)
 RegisterNetEvent('police:client:GetCuffed', function(playerId, isSoftcuff)
     if not QBX.PlayerData.metadata.ishandcuffed then
         TriggerServerEvent('police:server:SetHandcuffStatus', true)
-        LocalPlayer.state.invBusy = true
         ClearPedTasksImmediately(cache.ped)
         if cache.weapon ~= `WEAPON_UNARMED` then
             SetCurrentPedWeapon(cache.ped, `WEAPON_UNARMED`, true)
@@ -339,7 +343,6 @@ RegisterNetEvent('police:client:GetCuffed', function(playerId, isSoftcuff)
                 local isSuccess = lib.skillCheck(config.breakCuffsDifficulty, config.breakCuffsKeys)
                 if isSuccess then
                     TriggerServerEvent('police:server:SetHandcuffStatus', false)
-                    LocalPlayer.state.invBusy = false
                     ClearPedTasksImmediately(cache.ped)
                     exports.qbx_core:Notify(locale('success.escapedcuff'), 'success')
                     return
@@ -354,7 +357,6 @@ RegisterNetEvent('police:client:GetCuffed', function(playerId, isSoftcuff)
         TriggerEvent('hospital:client:isEscorted', IsEscorted)
         DetachEntity(cache.ped, true, false)
         TriggerServerEvent('police:server:SetHandcuffStatus', false)
-        LocalPlayer.state.invBusy = false
         ClearPedTasksImmediately(cache.ped)
         TriggerServerEvent('InteractSound_SV:PlayOnSource', 'Uncuff', 0.2)
         exports.qbx_core:Notify(locale('success.uncuffed'), 'success')

--- a/server/main.lua
+++ b/server/main.lua
@@ -123,7 +123,7 @@ local function isPlateFlagged(plate)
 end
 
 
-lib.callback.register('qbx_police:server:isPlateFlagged', function(_, plate)
+lib.callback.register('police:server:isPlateFlagged', function(_, plate)
     return isPlateFlagged(plate)
 end)
 

--- a/server/main.lua
+++ b/server/main.lua
@@ -28,7 +28,7 @@ local function updateBlips()
             local ped = GetPlayerPed(source)
             local coords = GetEntityCoords(ped)
             local heading = GetEntityHeading(ped)
-            dutyPlayers[#dutyPlayers+1] = {
+            dutyPlayers[#dutyPlayers + 1] = {
                 job = job.name,
                 source = source,
                 label = playerData.metadata.callsign,
@@ -75,7 +75,9 @@ exports.qbx_core:CreateUseableItem('moneybag', function(source, item)
         or player.PlayerData.job.type == 'leo'
         or not player.Functions.GetItemByName('moneybag')
         or not player.Functions.RemoveItem('moneybag', 1, item.slot)
-    then return end
+    then
+        return
+    end
     player.Functions.AddMoney('cash', tonumber(item.info.cash), 'used-moneybag')
 end)
 
@@ -141,22 +143,24 @@ lib.callback.register('qbx_police:server:isPoliceForcePresent', isPoliceForcePre
 
 if GetConvar('qbx:enablebridge', 'true') == 'true' then
     local QBCore = exports['qb-core']:GetCoreObject()
-    ---@deprecated use qbx_police:server:isPlateFlagged
+    ---@deprecated use police:server:isPlateFlagged
     QBCore.Functions.CreateCallback('police:IsPlateFlagged', function(_, cb, plate)
-        lib.print.warn(GetInvokingResource(), 'invoked deprecated callback police:IsPlateFlagged. Use qbx_police:server:isPlateFlagged instead.')
+        lib.print.warn(GetInvokingResource(),
+            'invoked deprecated callback police:IsPlateFlagged. Use police:server:isPlateFlagged instead.')
         cb(isPlateFlagged(plate))
     end)
 
     ---@deprecated
     QBCore.Functions.CreateCallback('police:server:IsPoliceForcePresent', function(_, cb)
-        lib.print.warn(GetInvokingResource(), 'invoked deprecated callback police:server:IsPoliceForcePresent. Use lib callback qbx_police:server:isPoliceForcePresent instead')
+        lib.print.warn(GetInvokingResource(),
+            'invoked deprecated callback police:server:IsPoliceForcePresent. Use lib callback qbx_police:server:isPoliceForcePresent instead')
         cb(isPoliceForcePresent())
     end)
 end
 
 -- Events
 RegisterNetEvent('police:server:Radar', function(fine)
-    local src = source
+    local src    = source
     local price  = sharedConfig.radars.speedFines[fine].fine
     local player = exports.qbx_core:GetPlayer(src)
     if not player.Functions.RemoveMoney('bank', math.floor(price), 'Radar Fine') then return end
@@ -172,11 +176,16 @@ RegisterNetEvent('police:server:policeAlert', function(text, camId, playerSource
     for k, v in pairs(players) do
         if IsLeoAndOnDuty(v) then
             if camId then
-                local alertData = {title = locale('info.new_call'), coords = coords, description = text .. locale('info.camera_id') .. camId}
+                local alertData = {
+                    title = locale('info.new_call'),
+                    coords = coords,
+                    description = text ..
+                        locale('info.camera_id') .. camId
+                }
                 TriggerClientEvent('qb-phone:client:addPoliceAlert', k, alertData)
                 TriggerClientEvent('police:client:policeAlert', k, coords, text, camId)
             else
-                local alertData = {title = locale('info.new_call'), coords = coords, description = text}
+                local alertData = { title = locale('info.new_call'), coords = coords, description = text }
                 TriggerClientEvent('qb-phone:client:addPoliceAlert', k, alertData)
                 TriggerClientEvent('police:client:policeAlert', k, coords, text)
             end
@@ -323,6 +332,7 @@ RegisterNetEvent('police:server:SetHandcuffStatus', function(isHandcuffed)
     local player = exports.qbx_core:GetPlayer(source)
     if not player then return end
     player.Functions.SetMetaData('ishandcuffed', isHandcuffed)
+    Player(source).state.invBusy = isHandcuffed
 end)
 
 RegisterNetEvent('heli:spotlight', function(state)
@@ -336,7 +346,12 @@ RegisterNetEvent('police:server:FlaggedPlateTriggered', function(radar, plate, s
     local players = exports.qbx_core:GetQBPlayers()
     for i = 1, #players do
         if IsLeoAndOnDuty(players[i]) then
-            local alertData = {title = locale('info.new_call'), coords = coords, description = locale('info.plate_triggered', plate, street, radar)}
+            local alertData = {
+                title = locale('info.new_call'),
+                coords = coords,
+                description = locale(
+                    'info.plate_triggered', plate, street, radar)
+            }
             TriggerClientEvent('qb-phone:client:addPoliceAlert', i, alertData)
             TriggerClientEvent('police:client:policeAlert', i, coords, locale('info.plate_triggered_blip', radar))
         end
@@ -431,16 +446,16 @@ end)
 RegisterNetEvent('evidence:server:AddBlooddropToInventory', function(bloodId, bloodInfo)
     local src = source
     local player = exports.qbx_core:GetPlayer(src)
-    local playerName = player.PlayerData.charinfo.firstname..' '..player.PlayerData.charinfo.lastname
+    local playerName = player.PlayerData.charinfo.firstname .. ' ' .. player.PlayerData.charinfo.lastname
     local streetName = bloodInfo.street
     local bloodType = bloodInfo.bloodtype
     local bloodDNA = bloodInfo.dnalabel
     local metadata = {}
     metadata.type = 'Blood Evidence'
-    metadata.description = 'DNA ID: '..bloodDNA
-    metadata.description = metadata.description..'\n\nBlood Type: '..bloodType
-    metadata.description = metadata.description..'\n\nCollected By: '..playerName
-    metadata.description = metadata.description..'\n\nCollected At: '..streetName
+    metadata.description = 'DNA ID: ' .. bloodDNA
+    metadata.description = metadata.description .. '\n\nBlood Type: ' .. bloodType
+    metadata.description = metadata.description .. '\n\nCollected By: ' .. playerName
+    metadata.description = metadata.description .. '\n\nCollected At: ' .. streetName
     if not exports.ox_inventory:RemoveItem(src, 'empty_evidence_bag', 1) then
         return exports.qbx_core:Notify(src, locale('error.have_evidence_bag'), 'error')
     end
@@ -453,14 +468,14 @@ end)
 RegisterNetEvent('evidence:server:AddFingerprintToInventory', function(fingerId, fingerInfo)
     local src = source
     local player = exports.qbx_core:GetPlayer(src)
-    local playerName = player.PlayerData.charinfo.firstname..' '..player.PlayerData.charinfo.lastname
+    local playerName = player.PlayerData.charinfo.firstname .. ' ' .. player.PlayerData.charinfo.lastname
     local streetName = fingerInfo.street
     local fingerprint = fingerInfo.fingerprint
     local metadata = {}
     metadata.type = 'Fingerprint Evidence'
-    metadata.description = 'Fingerprint ID: '..fingerprint
-    metadata.description = metadata.description..'\n\nCollected By: '..playerName
-    metadata.description = metadata.description..'\n\nCollected At: '..streetName
+    metadata.description = 'Fingerprint ID: ' .. fingerprint
+    metadata.description = metadata.description .. '\n\nCollected By: ' .. playerName
+    metadata.description = metadata.description .. '\n\nCollected At: ' .. streetName
     if not exports.ox_inventory:RemoveItem(src, 'empty_evidence_bag', 1) then
         return exports.qbx_core:Notify(src, locale('error.have_evidence_bag'), 'error')
     end
@@ -474,7 +489,7 @@ RegisterNetEvent('evidence:server:CreateCasing', function(weapon, serial, coords
     local casingId = generateId(casings)
     local serieNumber = exports.ox_inventory:GetCurrentWeapon(source).metadata.serial
     if not serieNumber then
-    serieNumber = serial
+        serieNumber = serial
     end
     TriggerClientEvent('evidence:client:AddCasing', -1, casingId, weapon, coords, serieNumber)
 end)
@@ -505,16 +520,16 @@ end)
 RegisterNetEvent('evidence:server:AddCasingToInventory', function(casingId, casingInfo)
     local src = source
     local player = exports.qbx_core:GetPlayer(src)
-    local playerName = player.PlayerData.charinfo.firstname..' '..player.PlayerData.charinfo.lastname
+    local playerName = player.PlayerData.charinfo.firstname .. ' ' .. player.PlayerData.charinfo.lastname
     local streetName = casingInfo.street
     local ammoType = casingInfo.ammolabel
     local serialNumber = casingInfo.serie
     local metadata = {}
     metadata.type = 'Casing Evidence'
-    metadata.description = 'Ammo Type: '..ammoType
-    metadata.description = metadata.description..'\n\nSerial #: '..serialNumber
-    metadata.description = metadata.description..'\n\nCollected By: '..playerName
-    metadata.description = metadata.description..'\n\nCollected At: '..streetName
+    metadata.description = 'Ammo Type: ' .. ammoType
+    metadata.description = metadata.description .. '\n\nSerial #: ' .. serialNumber
+    metadata.description = metadata.description .. '\n\nCollected By: ' .. playerName
+    metadata.description = metadata.description .. '\n\nCollected At: ' .. streetName
     if not exports.ox_inventory:RemoveItem(src, 'empty_evidence_bag', 1) then
         return exports.qbx_core:Notify(src, locale('error.have_evidence_bag'), 'error')
     end
@@ -547,12 +562,16 @@ RegisterNetEvent('police:server:SetTracker', function(targetId)
     if trackerMeta then
         target.Functions.SetMetaData('tracker', false)
         exports.qbx_core:Notify(targetId, locale('success.anklet_taken_off'), 'success')
-        exports.qbx_core:Notify(src, locale('success.took_anklet_from', target.PlayerData.charinfo.firstname, target.PlayerData.charinfo.lastname), 'success')
+        exports.qbx_core:Notify(src,
+            locale('success.took_anklet_from', target.PlayerData.charinfo.firstname, target.PlayerData.charinfo.lastname),
+            'success')
         TriggerClientEvent('police:client:SetTracker', targetId, false)
     else
         target.Functions.SetMetaData('tracker', true)
         exports.qbx_core:Notify(targetId, locale('success.put_anklet'), 'success')
-        exports.qbx_core:Notify(src, locale('success.put_anklet_on', target.PlayerData.charinfo.firstname, target.PlayerData.charinfo.lastname), 'success')
+        exports.qbx_core:Notify(src,
+            locale('success.put_anklet_on', target.PlayerData.charinfo.firstname, target.PlayerData.charinfo.lastname),
+            'success')
         TriggerClientEvent('police:client:SetTracker', targetId, true)
     end
 end)
@@ -568,7 +587,8 @@ AddEventHandler('onServerResourceStart', function(resource)
     end
 
     for i = 1, #sharedConfig.locations.trash do
-        exports.ox_inventory:RegisterStash(('policetrash_%s'):format(i), 'Police Trash', 300, 4000000, nil, jobs, sharedConfig.locations.trash[i])
+        exports.ox_inventory:RegisterStash(('policetrash_%s'):format(i), 'Police Trash', 300, 4000000, nil, jobs,
+            sharedConfig.locations.trash[i])
     end
     exports.ox_inventory:RegisterStash('policelocker', 'Police Locker', 30, 100000, true)
 end)


### PR DESCRIPTION
## Description

Callback named `qbx_police:server:isPlateFlagged` is registered on the server, but on the client it's name is `police:server:isPlateFlagged`, which is then throwing an error when the vehicle drives next to the speed camera. This PR fixes this issue.
Additionally, we are preventing players from accessing their inventory while they are cuffed.

## Checklist

- [X] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [X] My pull request fits the contribution guidelines & code conventions.
